### PR TITLE
Removing resolve and reject from the object returned by defer.promise()

### DIFF
--- a/spec/node/modules/promise-exposed-methods.spec.js
+++ b/spec/node/modules/promise-exposed-methods.spec.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('Promises/Exposed methods', function() {
+    var expect = require("expect.js");
+    var promise = require("../../../promise.js");
+
+    it("resolve/reject", function() {
+        var instance = promise();
+        var res = instance.promise();
+        expect(instance.resolve).to.be.a("function");
+        expect(instance.reject).to.be.a("function");
+        expect(res.resolve).to.be.an("undefined");
+        expect(res.reject).to.be.an("undefined");
+    });
+
+});

--- a/src/modules/promise.js
+++ b/src/modules/promise.js
@@ -77,7 +77,7 @@ var createPromise = function() {
         };
         addCb("", asyncCall.nextTickApply);
         addCb("Sync", asyncCall.syncApply);
-        promise[resolveOrReject] = function() {
+        deferred[resolveOrReject] = function() {
             if (state !== PENDING_STATE) {
                 return;
             }


### PR DESCRIPTION
When doing:

``` js
var promise = require("noder-js/promise");
var defer = promise();
var res = defer.promise();
```

`resolve` and `reject` were incorrectly present on the `res` object.
