### PR TITLE
Simplifying the use of asyncRequire.

### DIFF
--- a/asyncRequire.js
+++ b/asyncRequire.js
@@ -16,23 +16,26 @@
 var defer = require('./promise').defer;
 var typeUtils = require('./src/modules/type');
 
-module.exports = {
-    create: function(module) {
-        return function() {
-            var deferred = defer();
-            var result = [];
-            try {
-                for (var i = 0, l = arguments.length; i < l; i++) {
-                    var item = arguments[i];
-                    if (typeUtils.isString(item)) {
-                        result[i] = module.require(item);
-                    }
+var create = function(module) {
+    var res = function() {
+        var deferred = defer();
+        var result = [];
+        try {
+            for (var i = 0, l = arguments.length; i < l; i++) {
+                var item = arguments[i];
+                if (typeUtils.isString(item)) {
+                    result[i] = module.require(item);
                 }
-                deferred.resolve.apply(deferred, result);
-            } catch (e) {
-                deferred.reject(e);
             }
-            return deferred.promise;
-        };
-    }
+            deferred.resolve.apply(deferred, result);
+        } catch (e) {
+            deferred.reject(e);
+        }
+        return deferred.promise;
+    };
+    res.create = create;
+    return res;
 };
+
+
+module.exports = create(module);

--- a/src/modules/context.js
+++ b/src/modules/context.js
@@ -38,10 +38,15 @@ var bind = function(fn, scope) {
     };
 };
 
-var bindAsyncRequire = function(context, module) {
-    return function() {
-        return context.moduleAsyncRequire(module, arguments);
+var createAsyncRequire = function(context) {
+    var create = function(module) {
+        var res = function() {
+            return context.moduleAsyncRequire(module, arguments);
+        };
+        res.create = create;
+        return res;
     };
+    return create;
 };
 
 var Module = function(context, filename) {
@@ -118,7 +123,7 @@ var Context = function(config) {
     rootModule.preloaded = true;
     rootModule.loaded = true;
     rootModule.define = this.define = bind(this.define, this);
-    rootModule.asyncRequire = bindAsyncRequire(this, rootModule);
+    rootModule.asyncRequire = createAsyncRequire(this)(rootModule);
     rootModule.execute = bind(this.jsModuleExecute, this);
     rootModule.createContext = Context.createContext;
     this.rootModule = rootModule;
@@ -371,11 +376,7 @@ contextProto.execModuleCall = function(moduleFilename) {
 Context.builtinModules = BuiltinModules.prototype = {
     "/noder-js/asyncRequire.js": function(context) {
         return function(module) {
-            module.exports = {
-                create: function(module) {
-                    return bindAsyncRequire(context, module);
-                }
-            };
+            module.exports = context.rootModule.asyncRequire;
         };
     },
     "/noder-js/currentContext.js": function(context) {


### PR DESCRIPTION
When not using relative paths, it is now possible to do:

``` js
  var asyncRequire = require("noder-js/asyncRequire");
  asyncRequire("myModule").then(function(myModule){...})
```

The previous way still works:

``` js
  var asyncRequire = require("noder-js/asyncRequire").create(module);
  asyncRequire("myModule").then(function(myModule){...})
```

When using relative paths, it is now possible to do:

``` js
  var asyncRequire = require("noder-js/asyncRequire");
  asyncRequire(require.resolve("./myModule")).then(function(myModule){...});
```

The previous way still works:

``` js
  var asyncRequire = require("noder-js/asyncRequire").create(module);
  asyncRequire("./myModule").then(function(myModule){...});
```

However, the following use case should be avoided:

``` js
  var asyncRequire = require("noder-js/asyncRequire");
  asyncRequire("./myModule").then(function(myModule){...});
```

because then, the path is not relative to the current module, but to another (unspecified) one.
