### PR TITLE
[Non backward compatible] Making promises more compliant with standards

### DIFF
--- a/asyncRequire.js
+++ b/asyncRequire.js
@@ -13,25 +13,22 @@
  * limitations under the License.
  */
 
-var defer = require('./promise').defer;
+var Promise = require('./promise');
 var typeUtils = require('./src/modules/type');
 
 var create = function(module) {
     var res = function() {
-        var deferred = defer();
-        var result = [];
-        try {
-            for (var i = 0, l = arguments.length; i < l; i++) {
-                var item = arguments[i];
+        var args = arguments;
+        return new Promise(function(fulfill) {
+            var result = [];
+            for (var i = 0, l = args.length; i < l; i++) {
+                var item = args[i];
                 if (typeUtils.isString(item)) {
                     result[i] = module.require(item);
                 }
             }
-            deferred.resolve.apply(deferred, result);
-        } catch (e) {
-            deferred.reject(e);
-        }
-        return deferred.promise;
+            fulfill(result);
+        });
     };
     res.create = create;
     return res;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "karma-sauce-launcher": "0.2.3",
         "load-grunt-tasks": "0.3.0",
         "mocha": "1.8.2",
-        "promises-aplus-tests": "1.3.2",
+        "promises-aplus-tests": "2.0.4",
         "highlight.js": "8.0.0",
         "js-yaml": "3.0.2"
     },

--- a/spec/browser/loaderPlugin-tests/$plugin.js
+++ b/spec/browser/loaderPlugin-tests/$plugin.js
@@ -14,7 +14,7 @@
  */
 
 // ./$plugin.js and ./notPlugin are supposed to be and stay exactly identical.
-var promise = require("noder-js/promise");
+var Promise = require("noder-js/promise");
 var preloadCalls = [];
 var slice = Array.prototype.slice;
 
@@ -36,7 +36,7 @@ var pluginMethod = function() {
 };
 
 pluginMethod.$preload = function() {
-    var deferred = promise.defer();
+    var deferred = Promise.defer();
     var item = {
         args: slice.call(arguments, 0),
         resolved: false

--- a/spec/browser/loaderPlugin-tests/notPlugin.js
+++ b/spec/browser/loaderPlugin-tests/notPlugin.js
@@ -14,7 +14,7 @@
  */
 
 // ./$plugin.js and ./notPlugin are supposed to be and stay exactly identical.
-var promise = require("noder-js/promise");
+var Promise = require("noder-js/promise");
 var preloadCalls = [];
 var slice = Array.prototype.slice;
 
@@ -36,7 +36,7 @@ var pluginMethod = function() {
 };
 
 pluginMethod.$preload = function() {
-    var deferred = promise.defer();
+    var deferred = Promise.defer();
     var item = {
         args: slice.call(arguments, 0),
         resolved: false

--- a/spec/browser/loaderPlugin.spec.js
+++ b/spec/browser/loaderPlugin.spec.js
@@ -37,7 +37,7 @@ describe("Loader plugins", function() {
                 }
             });
 
-            newRootModule.asyncRequire(fileName).then(function(pluginUsage1) {
+            newRootModule.asyncRequire(fileName).spread(function(pluginUsage1) {
                 var cache = newRootModule.require.cache;
                 var pluginUsage1Module = cache[fileName];
                 var pluginModule = cache["$plugin.js"];
@@ -67,7 +67,7 @@ describe("Loader plugins", function() {
                 }
             });
 
-            newRootModule.asyncRequire(fileName).then(function(pluginUsage2) {
+            newRootModule.asyncRequire(fileName).spread(function(pluginUsage2) {
                 var cache = newRootModule.require.cache;
                 var pluginUsage2Module = cache[fileName];
                 var pluginModule = cache["$plugin.js"];

--- a/spec/browser/main.spec.js
+++ b/spec/browser/main.spec.js
@@ -34,7 +34,7 @@ describe("Main", function() {
                 baseUrl: directory + '/main-tests/simple/'
             }
         });
-        newRootModule.asyncRequire('file1').then(function(file1) {
+        newRootModule.asyncRequire('file1').spread(function(file1) {
             expect(file1.test1()).to.equal('simple-ok1');
             expect(file1.test2()).to.equal('simple-ok2');
             expect(file1.test3()).to.equal('simple-ok3');
@@ -66,7 +66,7 @@ describe("Main", function() {
                 baseUrl: directory + '/main-tests/circularDependency/'
             }
         });
-        newRootModule.asyncRequire('file1', 'file2').then(function(file1, file2) {
+        newRootModule.asyncRequire('file1', 'file2').spread(function(file1, file2) {
             expect(file1.test1()).to.equal('ok1');
             expect(file1.test2()).to.equal('ok2');
 

--- a/spec/browser/preprocessors-tests/asyncPreprocessor1.js
+++ b/spec/browser/preprocessors-tests/asyncPreprocessor1.js
@@ -12,10 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var promise = require("noder-js/promise");
+var Promise = require("noder-js/promise");
 
 module.exports = function(code, fileName) {
-    var defer = promise.defer();
+    var defer = Promise.defer();
     setTimeout(function() {
         var res = code.replace(/<PREPROCESSOR1-FILENAME>/g, fileName);
         res = res.replace(/<PREPROCESSOR1-CHANGE1>/g, "<PREPROCESSOR2-CHANGE2>");

--- a/spec/browser/preprocessors-tests/asyncPreprocessor2.js
+++ b/spec/browser/preprocessors-tests/asyncPreprocessor2.js
@@ -12,10 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var promise = require("noder-js/promise");
+var Promise = require("noder-js/promise");
 
 module.exports = function(code, fileName) {
-    var defer = promise.defer();
+    var defer = Promise.defer();
     setTimeout(function() {
         var res = code.replace(/<PREPROCESSOR2-FILENAME>/g, fileName);
         res = res.replace(/<PREPROCESSOR2-CHANGE1>/g, "<PREPROCESSOR1-CHANGE2>");

--- a/spec/browser/preprocessors.spec.js
+++ b/spec/browser/preprocessors.spec.js
@@ -42,7 +42,7 @@ describe("Preprocessors", function() {
             });
             var isSync = true;
 
-            newRootModule.asyncRequire("originalFile").thenSync(function(result) {
+            newRootModule.asyncRequire("originalFile").spreadSync(function(result) {
                 expect(result).to.eql(expectedResult);
                 expect(isSync).to.equal(sync);
                 if (sync) {

--- a/spec/node/modules/promise-all.spec.js
+++ b/spec/node/modules/promise-all.spec.js
@@ -15,7 +15,7 @@
 
 describe('Promises/When', function() {
     var expect = require("expect.js");
-    var promise = require("../../../promise.js");
+    var Promise = require("../../../promise.js");
 
     var myValue = {};
     var myFunction = function() {
@@ -23,7 +23,7 @@ describe('Promises/When', function() {
     };
 
     var checkResult = function(promiseValue, done) {
-        promiseValue.then(function(value) {
+        promiseValue.spread(function(value) {
             expect(value).to.equal(myValue);
             done();
         }, function() {
@@ -31,49 +31,49 @@ describe('Promises/When', function() {
         });
     };
 
-    it("Direct value (when)", function(done) {
-        checkResult(promise.when([myFunction()]), done);
+    it("Direct value (all)", function(done) {
+        checkResult(Promise.all([myFunction()]), done);
     });
 
-    it("Chaining promises (when)", function(done) {
-        checkResult(promise.when([promise.done.then(myFunction)]), done);
+    it("Chaining promises (all)", function(done) {
+        checkResult(Promise.all([Promise.done.then(myFunction)]), done);
     });
 
-    it("Fail fast (when)", function(done) {
-        var unresolvedDefer = promise.defer();
-        var errorDefer = promise.defer();
+    it("Fail fast (all)", function(done) {
+        var unresolvedDefer = Promise.defer();
+        var errorDefer = Promise.defer();
         var myError = {};
         errorDefer.reject(myError);
-        promise.when([unresolvedDefer.promise, errorDefer.promise]).then(function() {
+        Promise.all([unresolvedDefer.promise, errorDefer.promise]).then(function() {
             done(new Error("The success callback should not be called."));
         }, function(raisedError) {
             expect(raisedError).to.equal(myError);
             done();
-        }).end();
+        }).done();
     });
 
 
-    it("Direct value (whenAll)", function(done) {
-        checkResult(promise.whenAll([myFunction()]), done);
+    it("Direct value (allSettled)", function(done) {
+        checkResult(Promise.allSettled([myFunction()]), done);
     });
 
-    it("Chaining promises (whenAll)", function(done) {
-        checkResult(promise.whenAll([promise.done.then(myFunction)]), done);
+    it("Chaining promises (allSettled)", function(done) {
+        checkResult(Promise.allSettled([Promise.done.then(myFunction)]), done);
     });
 
-    it("Fail slow (whenAll)", function(done) {
+    it("Fail slow (allSettled)", function(done) {
         var later = false;
-        var resolveLaterDefer = promise.defer();
-        var errorDefer = promise.defer();
+        var resolveLaterDefer = Promise.defer();
+        var errorDefer = Promise.defer();
         var myError = {};
         errorDefer.reject(myError);
-        promise.whenAll([resolveLaterDefer.promise, errorDefer.promise]).then(function() {
+        Promise.allSettled([resolveLaterDefer.promise, errorDefer.promise]).then(function() {
             done(new Error("The success callback should not be called."));
         }, function(raisedError) {
             expect(later).to.equal(true);
             expect(raisedError).to.equal(myError);
             done();
-        }).end();
+        }).done();
         setTimeout(function() {
             later = true;
             resolveLaterDefer.resolve();

--- a/spec/node/modules/promise.spec.js
+++ b/spec/node/modules/promise.spec.js
@@ -14,17 +14,13 @@
  */
 
 describe("Promises/A+ Tests", function() {
-    var defer = require('../../../promise.js').defer;
+    var Promise = require('../../../promise.js');
 
     require("promises-aplus-tests").mocha({
-        pending: function() {
-            var deferred = defer();
-
-            return {
-                promise: deferred.promise,
-                fulfill: deferred.resolve,
-                reject: deferred.reject
-            };
+        resolved: Promise.resolve,
+        rejected: Promise.reject,
+        deferred: function() {
+            return Promise.defer();
         }
     });
 

--- a/src/modules/filters.js
+++ b/src/modules/filters.js
@@ -13,19 +13,19 @@
  * limitations under the License.
  */
 
-var promise = require("./promise");
+var Promise = require("./promise");
 
 module.exports = function(context, filterConfig, filename, args) {
     var items = (filterConfig || []).slice(0);
     var next = function(content) {
         args[0] = content;
         if (!items.length) {
-            return promise.when(content);
+            return Promise.resolve(content);
         }
         var currentFilter = items.shift();
         if (currentFilter.pattern && currentFilter.pattern.test(filename)) {
-            return context.moduleAsyncRequire(context.rootModule, [currentFilter.module]).thenSync(function(processor) {
-                return promise.when(processor.apply(this, args.concat(currentFilter.options))).thenSync(next);
+            return context.moduleAsyncRequire(context.rootModule, [currentFilter.module]).spreadSync(function(processor) {
+                return Promise.resolve(processor.apply(null, args.concat(currentFilter.options))).thenSync(next);
             });
         } else {
             return next(args[0]);

--- a/src/modules/type.js
+++ b/src/modules/type.js
@@ -25,6 +25,10 @@ var isFunction = function(fn) {
     return (typeof fn == "function");
 };
 
+var isObject = function(obj) {
+    return obj && (typeof obj == "object");
+};
+
 var isPlainObject = function(obj) {
     return obj ? toString.call(obj) === '[object Object]' : false;
 };
@@ -33,5 +37,6 @@ module.exports = {
     isFunction: isFunction,
     isArray: isArray,
     isString: isString,
+    isObject: isObject,
     isPlainObject: isPlainObject
 };

--- a/src/node-modules/request.js
+++ b/src/node-modules/request.js
@@ -14,7 +14,7 @@
  */
 
 var fs = require('fs');
-var promise = require('../modules/promise.js');
+var Promise = require('../modules/promise.js');
 
 var readFileSync = function(file, encoding, callback) {
     try {
@@ -25,14 +25,16 @@ var readFileSync = function(file, encoding, callback) {
 };
 
 module.exports = function(url, options) {
-    var deferred = promise.defer();
-    var readFile = options && options.sync ? readFileSync : fs.readFile;
-    readFile(url, 'utf-8', function(err, data) {
-        if (err) {
-            deferred.reject(err);
-        } else {
-            deferred.resolve(data);
-        }
+    return new Promise(function(fulfill, reject) {
+        var readFile = options && options.sync ? readFileSync : fs.readFile;
+        readFile(url, 'utf-8', function(err, data) {
+            if (err) {
+                reject(err);
+            } else {
+                fulfill({
+                    responseText: data
+                });
+            }
+        });
     });
-    return deferred.promise;
 };

--- a/src/plugins/noderError/error.js
+++ b/src/plugins/noderError/error.js
@@ -14,12 +14,12 @@
  */
 
 var asyncRequire = require('noder-js/asyncRequire').create(module);
-var promise = require('noder-js/promise');
+var Promise = require('noder-js/promise');
 
 var errorsList = {
     "XMLHttpRequest": function(out, url, xhr) {
         out.unshift("failed to download '", url, "': ", xhr.status, " ", xhr.statusText, "\n");
-        return promise.done;
+        return Promise.done;
     },
     "moduleLoadDefinition": function(out, module) {
         out.unshift("failed to load definition of module '", module.filename, "'\n");
@@ -39,14 +39,14 @@ var errorsList = {
         if (module.filename != '.') {
             out.unshift("invalid recursive call to modulePreload '", module.filename, "'\n");
         }
-        return promise.done;
+        return Promise.done;
     },
     "notPreloaded": function(out, module) {
         out.unshift("cannot execute module '", module.filename, "' as it is not preloaded.\n");
-        return this.cause ? unshiftErrorInfo(this.cause, out) : promise.done;
+        return this.cause ? unshiftErrorInfo(this.cause, out) : Promise.done;
     },
     "jsEval": function(out, jsCode, url /*, prefix, suffix*/ ) {
-        return asyncRequire('./evalError.js').thenSync(function(evalError) {
+        return asyncRequire('./evalError.js').spreadSync(function(evalError) {
             var syntaxError = evalError(out, jsCode, url);
             if (!syntaxError) {
                 out.unshift("error while evaluating '" + url + "'\n");
@@ -56,11 +56,11 @@ var errorsList = {
     },
     "resolverRoot": function(out, path) {
         out.unshift("trying to go upper than the root of modules when resolving '", path.join('/'), "'\n");
-        return promise.done;
+        return Promise.done;
     },
     "resolverLoop": function(out, path) {
         out.unshift("inifinite loop when resolving '", path.join('/'), "'\n");
-        return promise.done;
+        return Promise.done;
     }
 };
 
@@ -75,7 +75,7 @@ var unshiftErrorInfo = function(error, out) {
     } else {
         out.unshift(error + "\n");
     }
-    return promise.done;
+    return Promise.done;
 };
 
 module.exports = function(async) {


### PR DESCRIPTION
This pull request makes promises more compliant with standards, cf [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise):
- It adds support for the promise constructor:

``` js
var Promise = require("noder-js/promise");
var promiseInstance = new Promise(function(fulfill, reject){
   // ...
});
```
- It removes support for multiple arguments for handlers of `then` and `thenSync`. It adds the `spread` and `spreadSync` methods to pass the array fulfillment value to the handler as multiple arguments. This changes the API of `asyncRequire` and `request` in the following way:

Old usage:

``` js
// For the request module:
var request = require("noder-js/request");
request("myFile.txt").then(function (content, xhr) {
   // use content and xhr
});

// For the asyncRequire module:
var asyncRequire = require("noder-js/asyncRequire");
asyncRequire("moduleA","moduleB").then(function(moduleA, moduleB){
   // use moduleA and moduleB
});
```

New usage:

``` js
// For the request module:
var request = require("noder-js/request");
request("myFile.txt").then(function (xhr) {
   // The given parameter is directly the xhr object.
   // The content is now accessible with:
   var content = xhr.responseText;
   // use content and xhr
});

// For the asyncRequire module, it is possible to use either then or spread
var asyncRequire = require("noder-js/asyncRequire");
asyncRequire("moduleA","moduleB").then(function(array) {
   // The given parameter is now an array.
   var moduleA = array[0], moduleB = array[1];
   // use moduleA and moduleB
});

// or

var asyncRequire = require("noder-js/asyncRequire");
asyncRequire("moduleA","moduleB").spread(function(moduleA, moduleB) {
   // use moduleA and moduleB
});
```
- This pull request adds the following new methods (and removes the corresponding old ones):
  
  | New method (added) | Old method (removed) |
  | --- | --- |
  | `Promise.resolve` | _n/a_ |
  | `Promise.reject` | _n/a_ |
  | `Promise.all` | `Promise.when` |
  | `Promise.allSettled` | `Promise.whenAll` |
  | `promiseInstance.catch` | _n/a_ |
  | `promiseInstance.finally` | `promiseInstance.always` |
  | `promiseInstance.done` | `promiseInstance.end` |

Note that the `then`, `catch`, `finally` and `spread` methods have their equivalent `thenSync`, `catchSync`, `finallySync` and `spreadSync` methods, which call their handler synchronously if the promise is already either fulfilled or rejected at the time the `xSync` method is called.
- The promises implementation is now tested with the 2.0.4 (latest) version of [promises-aplus-tests](https://github.com/promises-aplus/promises-tests). This also means it is now possible to resolve a promise with another promise.
