### PR TITLE
Removing module.parent and module.children to avoid memory leaks.

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -19,8 +19,6 @@ in [Node.js](http://nodejs.org/api/globals.html):
 * [module.filename](http://nodejs.org/api/modules.html#modules_module_filename) and [module.id](http://nodejs.org/api/modules.html#modules_module_id)
 * [module.loaded](http://nodejs.org/api/modules.html#modules_module_loaded)
 * [module.require](http://nodejs.org/api/modules.html#modules_module_require_id)
-* [module.parent](http://nodejs.org/api/modules.html#modules_module_parent)
-* [module.children](http://nodejs.org/api/modules.html#modules_module_children)
 * [__filename](http://nodejs.org/api/globals.html#globals_filename)
 * [__dirname](http://nodejs.org/api/globals.html#globals_dirname)
 


### PR DESCRIPTION
To unload a module, it should be sufficient to do: `delete require.cache[modulePath]`.

It is not very intuitive to have to do:

``` js
var moduleToUnload = require.cache[modulePath];
var parentChildren = moduleToUnload.parent.children;
var index = parentChildren.indexOf(moduleToUnload);
parentChildren.splice(index, 1);
delete require.cache[modulePath];
```

Moreover, even if node.js [provides this feature](http://nodejs.org/api/modules.html#modules_module_parent), it is not very useful to have `module.parent` and `module.children`, so let's remove them to avoid any leak problem.
