### PR TITLE
Missing details in error messages on IE 7

### DIFF
--- a/spec/browser/main-tests/error/$pluginException.js
+++ b/spec/browser/main-tests/error/$pluginException.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var plugin = exports.plugin = function() {};
+
+plugin.$preload = function() {
+    throw new Error("this error from the plugin has to be reported!!!");
+};

--- a/spec/browser/main-tests/error/pluginException.js
+++ b/spec/browser/main-tests/error/pluginException.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require("./$pluginException").plugin();

--- a/spec/browser/main.spec.js
+++ b/spec/browser/main.spec.js
@@ -213,4 +213,13 @@ describe("Main", function() {
         expect(errorMsg).to.contain("syntax-end.error.js");
         expect(errorMsg).to.contain("line 7,");
     });
+
+    itChecksError("pluginException.js", function(error) {
+        if (error.logDetails) {
+            error.logDetails();
+        }
+        var errorMsg = error.message || error.description;
+        expect(errorMsg).to.contain("this error from the plugin has to be reported!!!");
+        expect(errorMsg).to.contain("failed to process plugin require(\'./$pluginException\').plugin for module \'pluginException.js\'");
+    });
 });

--- a/src/plugins/noderError/error.js
+++ b/src/plugins/noderError/error.js
@@ -65,15 +65,21 @@ var errorsList = {
 };
 
 var unshiftErrorInfo = function(error, out) {
-    if (error && error.name == "NoderError") {
-        var code = error.code;
-        var handler = errorsList[code];
-        if (handler) {
-            var params = [out].concat(error.args || []);
-            return handler.apply(error, params);
+    if (error) {
+        if (error.name == "NoderError") {
+            var code = error.code;
+            var handler = errorsList[code];
+            if (handler) {
+                var params = [out].concat(error.args || []);
+                return handler.apply(error, params);
+            }
+        } else {
+            if (error.name && (error.message || error.description)) {
+                out.unshift(error.name, ": ", error.message || error.description, "\n");
+            } else {
+                out.unshift(error + "\n");
+            }
         }
-    } else {
-        out.unshift(error + "\n");
     }
     return Promise.done;
 };


### PR DESCRIPTION
On IE 7, the toString method of an error object returns no information about the error (only the string "[object Error]"). It is necessary to use the description property instead.