### PR TITLE
Exposing module information (preloading status and dependencies)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -22,6 +22,11 @@ in [Node.js](http://nodejs.org/api/globals.html):
 * [__filename](http://nodejs.org/api/globals.html#globals_filename)
 * [__dirname](http://nodejs.org/api/globals.html#globals_dirname)
 
+The following extra properties are noderJS-specific:
+* `module.preloaded` is a boolean value indicating whether the module is fully preloaded (i.e. its definition and all its transitive dependencies are cached, so the module can be executed synchronously).
+* `module.noderInfo.dependencies` contains the array of static dependencies of the module (as returned by [findRequires](#findrequires-parser), with `detectLoaderPlugins = true`).
+* `module.noderInfo.preloading` contains either a falsy value, if the module preload did not started, or a promise which indicates the state of the preloading process (either pending, resolved or rejected).
+
 ## noder global variable
 
 noderJS creates a global variable called `noder` (its name is [configurable](configuration.md)).

--- a/spec/browser/loaderPlugin.spec.js
+++ b/spec/browser/loaderPlugin.spec.js
@@ -73,6 +73,9 @@ describe("Loader plugins", function() {
                 var pluginModule = cache["$plugin.js"];
                 var notPluginModule = cache["notPlugin.js"];
                 expect(pluginModule.exports.preloadCalls).to.length(usages);
+                expect(pluginUsage2Module.noderInfo.dependencies).to.length(2 /* for string values */ + usages /* for plugin calls */ );
+                expect(pluginUsage2Module.noderInfo.dependencies).to.contain("./$plugin");
+                expect(pluginUsage2Module.noderInfo.dependencies).to.contain("./notPlugin");
                 var preloadCalls = pluginModule.exports.preloadCalls;
                 for (var i = 0, l = preloadCalls.length; i < l; i++) {
                     expect(preloadCalls[i].resolved).to.equal(true);


### PR DESCRIPTION
This pull request exposes the following information on each module:
- `module.noderInfo.dependencies` contains the array of static dependencies of the module
- `module.noderInfo.preloading` contains either a falsy value, if the module preload did not started, or a promise which indicates the state of the preloading process (either pending, resolved or rejected)